### PR TITLE
5.5.0GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ﻿# DocuSign C# Client Changelog
  
+## [v5.5.0] - eSignature API v2.1-21.1.02.00 - 06/07/2021
+### Breaking
+- Removed methods `GetAccountSettingsExport`,`GetSealProviders` from Accounts.
+- Removed methods `CreateConnectSecret`,`DeleteConnectSecret`,`GenerateConnectSecret`,`GetConnectSecrets` from Connect.
+- Removed methods `GetDynamicSystemSettings`,`GetTemplateInfo`,`GetApplianceInfo`,`GetAccount`,`GetCustomFields`,`GeleteCustomFieldsV2`,`GetDocumentPages`,`GetImage`,`GetLocalePolicy`,`UpdatePageInfo`,`CreatePageInfo`,`DeletePageInfo`,`UpdatePdf`,`GetPdf`,`GetPdfBlob`,`UpdatePdfBlob`,`CreatePdfBlob`,`UpdateRecipientDeniedDocumentCopy`,`DeleteRecipientDeniedDocumentCopy`,`GetSignerAttachment`,`DeleteSignerAttachment`, from Envelopes.
+- Removed methods `CompleteSignHash`,`GetUserInfo`,`HealthCheck`,`SignHashSessionInfo`,`UpdateTransaction` from TrustServiceProviders.
+- Removed methods `GetUserListExport` from Users.
+### Added
+- Added new methods `GetBulkSendBatchEnvelopes` to BulkEnvelopes.
+### Changed
+- Added support for version v2.1-21.1.02.00 of the DocuSign eSignature API.
+- Updated the SDK release version.
+ 
 ## [v5.5.0-rc] - eSignature API v2.1-21.1.02.00 - 05/20/2021
 ### Breaking
 - Removed methods `GetAccountSettingsExport`,`GetSealProviders` from Accounts.

--- a/sdk/src/DocuSign.eSign/Api/AccountsApi.cs
+++ b/sdk/src/DocuSign.eSign/Api/AccountsApi.cs
@@ -15031,6 +15031,7 @@ namespace DocuSign.eSign.Api
             // verify the required parameter 'resourceContentType' is set
             if (resourceContentType == null)
                 throw new ApiException(400, "Missing required parameter 'resourceContentType' when calling AccountsApi->UpdateBrandResourcesByContentType");
+            
             var localVarPath = "/v2.1/accounts/{accountId}/brands/{brandId}/resources/{resourceContentType}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
@@ -15156,7 +15157,6 @@ namespace DocuSign.eSign.Api
             if (accountId != null) localVarPathParams.Add("accountId", this.ApiClient.ParameterToString(accountId)); // path parameter
             if (brandId != null) localVarPathParams.Add("brandId", this.ApiClient.ParameterToString(brandId)); // path parameter
             if (resourceContentType != null) localVarPathParams.Add("resourceContentType", this.ApiClient.ParameterToString(resourceContentType)); // path parameter
-
 
             // authentication (docusignAccessCode) required
             // oauth required

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "5.5.0-rc";
+        public const string Version = "5.5.0";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -24,7 +24,7 @@ Contact: devcenter@docusign.com
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>5.5.0-rc</VersionPrefix>
+    <VersionPrefix>5.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,7 +34,7 @@ Contact: devcenter@docusign.com
     <PackageLicenseUrl>https://github.com/docusign/docusign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[5.5.0-rc] - eSignature API v2.1-21.1.02.00 - 05/20/2021</PackageReleaseNotes>
+    <PackageReleaseNotes>[5.5.0] - eSignature API v2.1-21.1.02.00 - 06/07/2021 </PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- .NET Framework 4.5.2 compilation flags and build options -->

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.nuspec
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>DocuSign.eSign.dll</id>
-    <version>5.5.0-rc</version>
+    <version>5.5.0</version>
     <title>DocuSign.eSign</title>
     <authors>DocuSign</authors>
     <owners>DocuSign</owners>

--- a/sdk/src/DocuSign.eSign/Model/EnvelopeFormData.cs
+++ b/sdk/src/DocuSign.eSign/Model/EnvelopeFormData.cs
@@ -45,7 +45,7 @@ namespace DocuSign.eSign.Model
         /// <param name="RecipientFormData">RecipientFormData.</param>
         /// <param name="SentDateTime">The date and time the envelope was sent..</param>
         /// <param name="Status">Indicates the envelope status. Valid values are:  * sent - The envelope is sent to the recipients.  * created - The envelope is saved as a draft and can be modified and sent later..</param>
-        public EnvelopeFormData(string EmailSubject = default(string), string EnvelopeId = default(string), List<FormDataItem> FormData = default(List<FormDataItem>), List<FormDataItem> PrefillFormData = default(List<FormDataItem>), List<RecipientFormData> RecipientFormData = default(List<RecipientFormData>), string SentDateTime = default(string), string Status = default(string))
+        public EnvelopeFormData(string EmailSubject = default(string), string EnvelopeId = default(string), List<FormDataItem> FormData = default(List<FormDataItem>), EnvelopeFormDataPrefillFormData PrefillFormData = default(EnvelopeFormDataPrefillFormData), List<RecipientFormData> RecipientFormData = default(List<RecipientFormData>), string SentDateTime = default(string), string Status = default(string))
         {
             this.EmailSubject = EmailSubject;
             this.EnvelopeId = EnvelopeId;
@@ -77,7 +77,7 @@ namespace DocuSign.eSign.Model
         /// Gets or Sets PrefillFormData
         /// </summary>
         [DataMember(Name="prefillFormData", EmitDefaultValue=false)]
-        public List<FormDataItem> PrefillFormData { get; set; }
+        public EnvelopeFormDataPrefillFormData PrefillFormData { get; set; }
         /// <summary>
         /// Gets or Sets RecipientFormData
         /// </summary>
@@ -164,7 +164,7 @@ namespace DocuSign.eSign.Model
                 (
                     this.PrefillFormData == other.PrefillFormData ||
                     this.PrefillFormData != null &&
-                    this.PrefillFormData.SequenceEqual(other.PrefillFormData)
+                    this.PrefillFormData.Equals(other.PrefillFormData)
                 ) && 
                 (
                     this.RecipientFormData == other.RecipientFormData ||

--- a/sdk/src/DocuSign.eSign/Model/EnvelopeFormDataPrefillFormData.cs
+++ b/sdk/src/DocuSign.eSign/Model/EnvelopeFormDataPrefillFormData.cs
@@ -25,16 +25,30 @@ using SwaggerDateConverter = DocuSign.eSign.Client.SwaggerDateConverter;
 namespace DocuSign.eSign.Model
 {
     /// <summary>
-    /// DisplayApplianceInfo
+    /// EnvelopeFormDataPrefillFormData
     /// </summary>
     [DataContract]
-    public partial class DisplayApplianceInfo :  IEquatable<DisplayApplianceInfo>, IValidatableObject
+    public partial class EnvelopeFormDataPrefillFormData :  IEquatable<EnvelopeFormDataPrefillFormData>, IValidatableObject
     {
-        public DisplayApplianceInfo()
+        public EnvelopeFormDataPrefillFormData()
         {
             // Empty Constructor
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnvelopeFormDataPrefillFormData" /> class.
+        /// </summary>
+        /// <param name="FormData">FormData.</param>
+        public EnvelopeFormDataPrefillFormData(List<FormDataItem> FormData = default(List<FormDataItem>))
+        {
+            this.FormData = FormData;
+        }
         
+        /// <summary>
+        /// Gets or Sets FormData
+        /// </summary>
+        [DataMember(Name="formData", EmitDefaultValue=false)]
+        public List<FormDataItem> FormData { get; set; }
         /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
@@ -42,7 +56,8 @@ namespace DocuSign.eSign.Model
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append("class DisplayApplianceInfo {\n");
+            sb.Append("class EnvelopeFormDataPrefillFormData {\n");
+            sb.Append("  FormData: ").Append(FormData).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -64,21 +79,26 @@ namespace DocuSign.eSign.Model
         public override bool Equals(object obj)
         {
             // credit: http://stackoverflow.com/a/10454552/677735
-            return this.Equals(obj as DisplayApplianceInfo);
+            return this.Equals(obj as EnvelopeFormDataPrefillFormData);
         }
 
         /// <summary>
-        /// Returns true if DisplayApplianceInfo instances are equal
+        /// Returns true if EnvelopeFormDataPrefillFormData instances are equal
         /// </summary>
-        /// <param name="other">Instance of DisplayApplianceInfo to be compared</param>
+        /// <param name="other">Instance of EnvelopeFormDataPrefillFormData to be compared</param>
         /// <returns>Boolean</returns>
-        public bool Equals(DisplayApplianceInfo other)
+        public bool Equals(EnvelopeFormDataPrefillFormData other)
         {
             // credit: http://stackoverflow.com/a/10454552/677735
             if (other == null)
                 return false;
 
-            return false;
+            return 
+                (
+                    this.FormData == other.FormData ||
+                    this.FormData != null &&
+                    this.FormData.SequenceEqual(other.FormData)
+                );
         }
 
         /// <summary>
@@ -92,6 +112,8 @@ namespace DocuSign.eSign.Model
             {
                 int hash = 41;
                 // Suitable nullity checks etc, of course :)
+                if (this.FormData != null)
+                    hash = hash * 59 + this.FormData.GetHashCode();
                 return hash;
             }
         }

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "5.5.0-rc";
+    public const string AssemblyInformationalVersion = "5.5.0";
 }

--- a/test/SdkNetCoreTests/JwtAuthNetCoreUnitTests.cs
+++ b/test/SdkNetCoreTests/JwtAuthNetCoreUnitTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using DocuSign.eSign.Client.Auth;
 using System.Text;
+using System.Linq;
 
 namespace SdkNetCoreTests
 {
@@ -180,7 +181,7 @@ namespace SdkNetCoreTests
             Assert.IsNotNull(envelopeSummary);
             Assert.IsNotNull(envelopeSummary.EnvelopeId);
 
-            testConfig.EnvelopeId = envelopeSummary.EnvelopeId;
+            this.testConfig.EnvelopeId = envelopeSummary.EnvelopeId;
         }
 
         [TestMethod]
@@ -611,6 +612,81 @@ namespace SdkNetCoreTests
             }
         }
 
+        [TestMethod]
+        public void JwtListTabsTest()
+        {
+            EnvelopeDefinition envDef = new EnvelopeDefinition();
+            envDef.EmailSubject = "[DocuSign C# SDK] - Please sign this doc";
+
+            // assign recipient to template role by setting name, email, and role name.  Note that the
+            // template role name must match the placeholder role name saved in your account template.  
+            TemplateRole tRole = new TemplateRole();
+            tRole.Email = testConfig.RecipientEmail;
+            tRole.Name = testConfig.RecipientName;
+            tRole.RoleName = "Manager";
+
+            List<TemplateRole> rolesList = new List<TemplateRole>() { tRole };
+
+            // add the role to the envelope and assign valid templateId from your account
+            envDef.TemplateRoles = rolesList;
+            envDef.TemplateId = testConfig.TemplateId;
+
+            // set envelope status to "sent" to immediately send the signature request
+            envDef.Status = "sent";
+
+            // |EnvelopesApi| contains methods related to creating and sending Envelopes (aka signature requests)
+            EnvelopesApi envelopesApi = new EnvelopesApi(testConfig.ApiClient);
+            EnvelopeSummary envelopeSummary = envelopesApi.CreateEnvelope(testConfig.AccountId, envDef);
+
+            Assert.IsNotNull(envelopeSummary);
+            Assert.IsNotNull(envelopeSummary.EnvelopeId);
+
+            var recipients = envelopesApi.ListRecipients(testConfig.AccountId, envelopeSummary.EnvelopeId);
+            var tabs = envelopesApi.ListTabs(testConfig.AccountId, testConfig.EnvelopeId, recipients.Signers.FirstOrDefault().RecipientId);
+
+            Assert.IsNotNull(tabs);
+            Assert.IsNotNull(tabs.ListTabs);
+            Assert.IsInstanceOfType(tabs.ListTabs.FirstOrDefault(), typeof(DocuSign.eSign.Model.List));
+
+        }
+
+        [TestMethod]
+        public void JwtGetFormDataTest()
+        {
+            EnvelopeDefinition envDef = new EnvelopeDefinition();
+            envDef.EmailSubject = "[DocuSign C# SDK] - Please sign this doc";
+
+            // assign recipient to template role by setting name, email, and role name.  Note that the
+            // template role name must match the placeholder role name saved in your account template.  
+            TemplateRole tRole = new TemplateRole();
+            tRole.Email = testConfig.RecipientEmail;
+            tRole.Name = testConfig.RecipientName;
+            tRole.RoleName = "Manager";
+
+            List<TemplateRole> rolesList = new List<TemplateRole>() { tRole };
+
+            // add the role to the envelope and assign valid templateId from your account
+            envDef.TemplateRoles = rolesList;
+            envDef.TemplateId = testConfig.TemplateId;
+
+            // set envelope status to "sent" to immediately send the signature request
+            envDef.Status = "sent";
+
+            // |EnvelopesApi| contains methods related to creating and sending Envelopes (aka signature requests)
+            EnvelopesApi envelopesApi = new EnvelopesApi(testConfig.ApiClient);
+            EnvelopeSummary envelopeSummary = envelopesApi.CreateEnvelope(testConfig.AccountId, envDef);
+
+            Assert.IsNotNull(envelopeSummary);
+            Assert.IsNotNull(envelopeSummary.EnvelopeId);
+
+            EnvelopeFormData envFormData = envelopesApi.GetFormData(testConfig.AccountId, envelopeSummary.EnvelopeId);
+
+            Assert.IsNotNull(envFormData);
+            Assert.IsNotNull(envFormData.FormData);
+            Assert.IsNotNull(envFormData.EnvelopeId);
+            Assert.IsNotNull(envFormData.FormData.FirstOrDefault().Name);
+        }
+
         private void CreateBrandTest()
         {
             AccountsApi accApi = new AccountsApi(testConfig.ApiClient);
@@ -629,7 +705,7 @@ namespace SdkNetCoreTests
                 }
             }
         }
-        
+
         public void JwtMoveEnvelopesTest()
         {
             JwtRequestSignatureOnDocumentTest("sent");
@@ -642,7 +718,7 @@ namespace SdkNetCoreTests
 
             try
             {
-                var response = foldersApi.MoveEnvelopes(testConfig.AccountId, ToFolderId, foldersRequest);
+                foldersApi.MoveEnvelopes(testConfig.AccountId, ToFolderId, foldersRequest);
             }
             catch (Exception ex)
             {
@@ -651,22 +727,18 @@ namespace SdkNetCoreTests
 
             // Test if we moved the envelope to the correct folder
             FoldersApi.ListItemsOptions searchOptions = new FoldersApi.ListItemsOptions();
-            searchOptions.includeItems = "true";
 
             var listfromDraftsFolder = foldersApi.ListItems(testConfig.AccountId, ToFolderId, searchOptions);
 
             Assert.IsNotNull(listfromDraftsFolder);
 
             bool doesExists = false;
-            foreach (var folders in listfromDraftsFolder.Folders)
+            foreach (var folderItem in listfromDraftsFolder.FolderItems)
             {
-                foreach (var item in folders.FolderItems)
+                if (folderItem.EnvelopeId == testConfig.EnvelopeId)
                 {
-                    if (item.EnvelopeId == testConfig.EnvelopeId)
-                    {
-                        doesExists = true;
-                        break;
-                    }
+                    doesExists = true;
+                    break;
                 }
             }
 

--- a/test/SdkNetCoreTests/JwtAuthNetCoreUnitTests.cs
+++ b/test/SdkNetCoreTests/JwtAuthNetCoreUnitTests.cs
@@ -642,7 +642,7 @@ namespace SdkNetCoreTests
             Assert.IsNotNull(envelopeSummary.EnvelopeId);
 
             var recipients = envelopesApi.ListRecipients(testConfig.AccountId, envelopeSummary.EnvelopeId);
-            var tabs = envelopesApi.ListTabs(testConfig.AccountId, testConfig.EnvelopeId, recipients.Signers.FirstOrDefault().RecipientId);
+            var tabs = envelopesApi.ListTabs(testConfig.AccountId, envelopeSummary.EnvelopeId, recipients.Signers.FirstOrDefault().RecipientId);
 
             Assert.IsNotNull(tabs);
             Assert.IsNotNull(tabs.ListTabs);
@@ -733,12 +733,15 @@ namespace SdkNetCoreTests
             Assert.IsNotNull(listfromDraftsFolder);
 
             bool doesExists = false;
-            foreach (var folderItem in listfromDraftsFolder.FolderItems)
+            foreach (var folder in listfromDraftsFolder.Folders)
             {
-                if (folderItem.EnvelopeId == testConfig.EnvelopeId)
+                foreach (var item in folder.FolderItems)
                 {
-                    doesExists = true;
-                    break;
+                    if (item.EnvelopeId == testConfig.EnvelopeId)
+                    {
+                        doesExists = true;
+                        break;
+                    }
                 }
             }
 

--- a/test/SdkTests/JwtAuthUnitTests.cs
+++ b/test/SdkTests/JwtAuthUnitTests.cs
@@ -648,12 +648,15 @@ namespace SdkTests
             Assert.IsNotNull(listfromDraftsFolder);
 
             bool doesExists = false;
-            foreach (var folderItem in listfromDraftsFolder.FolderItems)
+            foreach (var folder in listfromDraftsFolder.Folders)
             {
-                if (folderItem.EnvelopeId == testConfig.EnvelopeId)
+                foreach (var item in folder.FolderItems)
                 {
-                    doesExists = true;
-                    break;
+                    if (item.EnvelopeId == testConfig.EnvelopeId)
+                    {
+                        doesExists = true;
+                        break;
+                    }
                 }
             }
 

--- a/test/SdkTests/JwtAuthUnitTests.cs
+++ b/test/SdkTests/JwtAuthUnitTests.cs
@@ -633,7 +633,7 @@ namespace SdkTests
 
             try
             {
-                foldersResponse = foldersApi.MoveEnvelopes(testConfig.AccountId, ToFolderId, foldersRequest);
+                foldersApi.MoveEnvelopes(testConfig.AccountId, ToFolderId, foldersRequest);
             }
             catch (Exception ex)
             {
@@ -642,22 +642,18 @@ namespace SdkTests
 
             // Test if we moved the envelope to the correct folder
             FoldersApi.ListItemsOptions searchOptions = new FoldersApi.ListItemsOptions();
-            searchOptions.includeItems = "true";
 
             var listfromDraftsFolder = foldersApi.ListItems(testConfig.AccountId, ToFolderId, searchOptions);
 
             Assert.IsNotNull(listfromDraftsFolder);
 
             bool doesExists = false;
-            foreach (var folders in listfromDraftsFolder.Folders)
+            foreach (var folderItem in listfromDraftsFolder.FolderItems)
             {
-                foreach (var item in folders.FolderItems)
+                if (folderItem.EnvelopeId == testConfig.EnvelopeId)
                 {
-                    if (item.EnvelopeId == testConfig.EnvelopeId)
-                    {
-                        doesExists = true;
-                        break;
-                    }
+                    doesExists = true;
+                    break;
                 }
             }
 

--- a/test/SdkTests462/JwtAuthUnitTests.cs
+++ b/test/SdkTests462/JwtAuthUnitTests.cs
@@ -635,7 +635,7 @@ namespace SdkTestsNet462
             Assert.IsNotNull(envelopeSummary.EnvelopeId);
 
             var recipients = envelopesApi.ListRecipients(testConfig.AccountId, envelopeSummary.EnvelopeId);
-            var tabs = envelopesApi.ListTabs(testConfig.AccountId, testConfig.EnvelopeId, recipients.Signers.FirstOrDefault().RecipientId);
+            var tabs = envelopesApi.ListTabs(testConfig.AccountId, envelopeSummary.EnvelopeId, recipients.Signers.FirstOrDefault().RecipientId);
 
             Assert.IsNotNull(tabs);
             Assert.IsNotNull(tabs.ListTabs);
@@ -727,12 +727,15 @@ namespace SdkTestsNet462
             Assert.IsNotNull(listfromDraftsFolder);
 
             bool doesExists = false;
-            foreach (var folderItems in listfromDraftsFolder.FolderItems)
+            foreach (var folder in listfromDraftsFolder.Folders)
             {
-                if (folderItems.EnvelopeId == testConfig.EnvelopeId)
+                foreach (var item in folder.FolderItems)
                 {
-                    doesExists = true;
-                    break;
+                    if (item.EnvelopeId == testConfig.EnvelopeId)
+                    {
+                        doesExists = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
## [v5.5.0] - eSignature API v2.1-21.1.02.00 - 06/07/2021
### Breaking
- Removed methods `GetAccountSettingsExport`,`GetSealProviders` from Accounts.
- Removed methods `CreateConnectSecret`,`DeleteConnectSecret`,`GenerateConnectSecret`,`GetConnectSecrets` from Connect.
- Removed methods `GetDynamicSystemSettings`,`GetTemplateInfo`,`GetApplianceInfo`,`GetAccount`,`GetCustomFields`,`GeleteCustomFieldsV2`,`GetDocumentPages`,`GetImage`,`GetLocalePolicy`,`UpdatePageInfo`,`CreatePageInfo`,`DeletePageInfo`,`UpdatePdf`,`GetPdf`,`GetPdfBlob`,`UpdatePdfBlob`,`CreatePdfBlob`,`UpdateRecipientDeniedDocumentCopy`,`DeleteRecipientDeniedDocumentCopy`,`GetSignerAttachment`,`DeleteSignerAttachment`, from Envelopes.
- Removed methods `CompleteSignHash`,`GetUserInfo`,`HealthCheck`,`SignHashSessionInfo`,`UpdateTransaction` from TrustServiceProviders.
- Removed methods `GetUserListExport` from Users.
### Added
- Added new methods `GetBulkSendBatchEnvelopes` to BulkEnvelopes.
### Changed
- Added support for version v2.1-21.1.02.00 of the DocuSign eSignature API.
- Updated the SDK release version.