### PR TITLE
Fix setting BasePath and OAuthBasePath in DocuSignClient ctors

### DIFF
--- a/sdk/src/DocuSign.eSign/Client/DocuSignClient.cs
+++ b/sdk/src/DocuSign.eSign/Client/DocuSignClient.cs
@@ -105,7 +105,7 @@ namespace DocuSign.eSign.Client
         {
             Configuration = configuration ?? new Configuration();
 
-            SetBasePath(string.IsNullOrEmpty(configuration.BasePath) ? configuration.BasePath : Production_REST_BasePath);
+            SetBasePath(string.IsNullOrEmpty(configuration.BasePath) ? Production_REST_BasePath : configuration.BasePath);
             RestClient = buildDefaultHttpClient(configuration?.Timeout ?? Configuration.DefaultTimeoutValue);
 
             SetOAuthBasePath();
@@ -120,13 +120,12 @@ namespace DocuSign.eSign.Client
         /// <param name="apiBase">The API base path</param>
         /// <param name="proxy">An optional IWebProxy instance</param>
         /// <exception cref="ArgumentException">Thwon when apiBase is null or empty</exception>
-        public DocuSignClient(String apiBase, IWebProxy proxy = null)
+        public DocuSignClient(string apiBase, IWebProxy proxy = null)
         {
             if (String.IsNullOrEmpty(apiBase))
                 throw new ArgumentException("apiBase cannot be empty");
 
             RestClient = buildDefaultHttpClient(Configuration.DefaultTimeoutValue, proxy);
-            Configuration = new Configuration(apiBase);
 
             RestClient.AddDefaultRequestHeader("User-Agent", Configuration.UserAgent);
 
@@ -142,7 +141,7 @@ namespace DocuSign.eSign.Client
         /// <param name="oAuthBase">The oAuth base path</param>
         /// <param name="proxy">An optional IWebProxy instance</param>
         /// <exception cref="ArgumentException">Thrown when apiBase or oAuthBase are null or empty</exception>
-        public DocuSignClient(String apiBase, String oAuthBase, IWebProxy proxy = null)
+        public DocuSignClient(string apiBase, string oAuthBase, IWebProxy proxy = null)
         {
             if (String.IsNullOrEmpty(apiBase))
                 throw new ArgumentException("apiBase cannot be empty");
@@ -152,8 +151,8 @@ namespace DocuSign.eSign.Client
             RestClient = buildDefaultHttpClient(Configuration.DefaultTimeoutValue, proxy);
             Configuration = new Configuration(apiBase);
 
-            this.SetBasePath(basePath);
-            this.SetOAuthBasePath();
+            this.SetBasePath(apiBase);
+            this.SetOAuthBasePath(oAuthBase);
         }
 
         /// <summary>

--- a/sdk/src/DocuSign.eSign/Client/DocuSignClient.cs
+++ b/sdk/src/DocuSign.eSign/Client/DocuSignClient.cs
@@ -126,6 +126,7 @@ namespace DocuSign.eSign.Client
                 throw new ArgumentException("apiBase cannot be empty");
 
             RestClient = buildDefaultHttpClient(Configuration.DefaultTimeoutValue, proxy);
+            Configuration = new Configuration(apiBase);
 
             RestClient.AddDefaultRequestHeader("User-Agent", Configuration.UserAgent);
 


### PR DESCRIPTION
_I lost 2 hours investigating why I'm getting `USER_AUTHENTICATION_FAILED` response. It was happening, because SDK was calling production API, instead of demo, even after providing BaseUrl for Demo to DocuSignClient constructor. 😐_

Current version of DocuSign SDK contains bug causing wrong assignment of BasePath while initializing DocuSignClient object.
Current workaround is to set api base path using `SetBasePath(basePath)`, but it should be done by constructor, when using overload: `public DocuSignClient(string apiBase, string oAuthBase, IWebProxy proxy = null)` **(line 155)**.

Also `Configuration = new Configuration(apiBase);` is useless in every constructor as SetBasePath method always calls it anyway but haven't touched it.