### PR TITLE
Version 6.9.0-rc2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ﻿# DocuSign C# Client Changelog
 
+## [v6.9.0-rc2] - eSignature API v2.1-23.4.02.00 - 2024-04-05
+### Breaking Changes
+- Updated C# SDK dependencies.
+    - Microsoft.CSharp: Version bumped from 4.5.0 to 4.7.0.
+    - Newtonsoft.Json: Version bumped from 13.0.1 to 13.0.3.
+    - System.ComponentModel.Annotations: Version bumped from 4.5.0 to 5.0.0.
+    - Microsoft.IdentityModel.Protocols: Version bumped from 5.4.0 to 7.3.1.
+    - System.IdentityModel.Tokens.Jwt: Version bumped from 5.4.0 to 7.3.1.
+    - BouncyCastle.Cryptography: Version bumped from 2.2.1 to 2.3.0.
+### Changed
+- Updated the SDK release version.
+
 ## [v6.9.0-rc1] - eSignature API v2.1-23.4.02.00 - 2024-03-12
 ### Changed
 - Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.

--- a/sdk/DocuSign.eSign.sln
+++ b/sdk/DocuSign.eSign.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{FB7B9B8D-5B21-410E-9F0B-52AD841F216E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FB7B9B8D-5B21-410E-9F0B-52AD841F216E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FB7B9B8D-5B21-410E-9F0B-52AD841F216E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FB7B9B8D-5B21-410E-9F0B-52AD841F216E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FB7B9B8D-5B21-410E-9F0B-52AD841F216E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "6.9.0-rc1";
+        public const string Version = "6.9.0-rc2";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>6.9.0-rc1</VersionPrefix>
+    <VersionPrefix>6.9.0-rc2</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v6.9.0-rc1] - ESignature API v2.1-23.4.02.00 - 3/12/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v6.9.0-rc2] - ESignature API v2.1-23.4.02.00 - 4/4/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>
@@ -38,12 +38,12 @@
     <Reference Include="System.Web"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0"/>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.4.0"/>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0"/>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1"/>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="7.3.1"/>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1"/>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0"/>
   </ItemGroup>
   <ItemGroup/>
 </Project>

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "6.9.0-rc1";
+    public const string AssemblyInformationalVersion = "6.9.0-rc2";
 }

--- a/test/SdkNetCoreTests/SdkNetCoreTests.csproj
+++ b/test/SdkNetCoreTests/SdkNetCoreTests.csproj
@@ -2,12 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
@@ -16,10 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.4.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="7.3.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SdkTests462/SdkTests462.csproj
+++ b/test/SdkTests462/SdkTests462.csproj
@@ -44,23 +44,29 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Cryptography, Version=2.0.0.0, Culture=neutral, PublicKeyToken=072edcf4a5328938, processorArchitecture=MSIL">
-      <HintPath>..\packages\BouncyCastle.Cryptography.2.2.1\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
+      <HintPath>..\packages\BouncyCastle.Cryptography.2.3.0\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="DocuSign.eSign">
       <HintPath>..\..\sdk\src\DocuSign.eSign\bin\Debug\net462\DocuSign.eSign.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.4.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.4.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.7.3.1\lib\net462\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.7.3.1\lib\net462\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.7.3.1\lib\net462\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.4.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.4.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.7.3.1\lib\net462\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -84,6 +90,9 @@
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
@@ -102,8 +111,8 @@
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
     </Reference>
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.4.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.7.3.1\lib\net462\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
@@ -121,6 +130,9 @@
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>
@@ -128,11 +140,17 @@
       <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
@@ -155,6 +173,18 @@
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.4.7.2\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />

--- a/test/SdkTests462/app.config
+++ b/test/SdkTests462/app.config
@@ -46,6 +46,46 @@
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.8.9.0" newVersion="1.8.9.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.4.0.0" newVersion="5.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/test/SdkTests462/packages.config
+++ b/test/SdkTests462/packages.config
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle.Cryptography" version="2.2.1" targetFramework="net462" />
+  <package id="BouncyCastle.Cryptography" version="2.3.0" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
-  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.4.0" targetFramework="net462" />
-  <package id="Microsoft.IdentityModel.Logging" version="5.4.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="7.3.1" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="7.3.1" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Logging" version="7.3.1" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Protocols" version="5.4.0" targetFramework="net462" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.4.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Tokens" version="7.3.1" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net462" />
@@ -15,6 +17,7 @@
   <package id="RestSharp" version="106.12.0" targetFramework="net462" />
   <package id="Sprache" version="2.3.1" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Collections" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net462" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net462" />
@@ -25,7 +28,7 @@
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net462" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.4.0" targetFramework="net462" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="7.3.1" targetFramework="net462" />
   <package id="System.IO" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />
@@ -33,15 +36,18 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net462" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
@@ -53,10 +59,14 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net462" />
+  <package id="System.Text.Json" version="4.7.2" targetFramework="net462" />
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net462" />
   <package id="System.Threading" version="4.3.0" targetFramework="net462" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
### Breaking Changes
- Updated C# SDK dependencies.
    - Microsoft.CSharp: Version bumped from 4.5.0 to 4.7.0.
    - Newtonsoft.Json: Version bumped from 13.0.1 to 13.0.3.
    - System.ComponentModel.Annotations: Version bumped from 4.5.0 to 5.0.0.
    - Microsoft.IdentityModel.Protocols: Version bumped from 5.4.0 to 7.3.1.
    - System.IdentityModel.Tokens.Jwt: Version bumped from 5.4.0 to 7.3.1.
    - BouncyCastle.Cryptography: Version bumped from 2.2.1 to 2.3.0.
### Changed
- Updated the SDK release version.