### PR TITLE
Version 7.0.0-rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# DocuSign C# Client Changelog
 
-## [v6.9.0-rc2] - eSignature API v2.1-23.4.02.00 - 2024-04-05
+## [v7.0.0-rc1] - eSignature API v2.1-23.4.02.00 - 2024-04-05
 ### Breaking Changes
 - Updated C# SDK dependencies.
     - Microsoft.CSharp: Version bumped from 4.5.0 to 4.7.0.

--- a/sdk/DocuSign.eSign.sln
+++ b/sdk/DocuSign.eSign.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{A1A634DA-0AF9-47C2-89D8-C5A6C8ECA80D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F0F1BD37-2496-4F88-B0BA-2EEA7E0F7070}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1A634DA-0AF9-47C2-89D8-C5A6C8ECA80D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A634DA-0AF9-47C2-89D8-C5A6C8ECA80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A634DA-0AF9-47C2-89D8-C5A6C8ECA80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A634DA-0AF9-47C2-89D8-C5A6C8ECA80D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "6.9.0-rc2";
+        public const string Version = "7.0.0-rc1";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>6.9.0-rc2</VersionPrefix>
+    <VersionPrefix>7.0.0-rc1</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v6.9.0-rc2] - ESignature API v2.1-23.4.02.00 - 4/4/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v7.0.0-rc1] - ESignature API v2.1-23.4.02.00 - 4/5/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "6.9.0-rc2";
+    public const string AssemblyInformationalVersion = "7.0.0-rc1";
 }


### PR DESCRIPTION
### Breaking Changes
- Updated C# SDK dependencies.
    - Microsoft.CSharp: Version bumped from 4.5.0 to 4.7.0.
    - Newtonsoft.Json: Version bumped from 13.0.1 to 13.0.3.
    - System.ComponentModel.Annotations: Version bumped from 4.5.0 to 5.0.0.
    - Microsoft.IdentityModel.Protocols: Version bumped from 5.4.0 to 7.3.1.
    - System.IdentityModel.Tokens.Jwt: Version bumped from 5.4.0 to 7.3.1.
    - BouncyCastle.Cryptography: Version bumped from 2.2.1 to 2.3.0.
### Changed
- Updated the SDK release version.