### PR TITLE
Version 8.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿# DocuSign C# Client Changelog
 
+## [v8.0.0] - eSignature API v2.1-24.2.00.00 - 2024-09-04
+### Changed
+- Updated the SDK release version.
 ## [v8.0.0-rc2] - eSignature API v2.1-24.2.00.00 - 2024-07-23
 ### Changed
 - Introduced async versions of `ApiClient` authorization methods.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: v2.1
-- **Latest SDK version (Including prerelease)**: 8.0.0-rc2
+- **Latest SDK version (Including prerelease)**: 8.0.0
 
 <a id="requirements"></a>
 ### Requirements

--- a/sdk/DocuSign.eSign.sln
+++ b/sdk/DocuSign.eSign.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{0DD2EBA2-97AB-491E-911A-01F064CA09E7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{C97D8E4E-1827-45EF-AA12-0457977A61BF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0DD2EBA2-97AB-491E-911A-01F064CA09E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0DD2EBA2-97AB-491E-911A-01F064CA09E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0DD2EBA2-97AB-491E-911A-01F064CA09E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0DD2EBA2-97AB-491E-911A-01F064CA09E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C97D8E4E-1827-45EF-AA12-0457977A61BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C97D8E4E-1827-45EF-AA12-0457977A61BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C97D8E4E-1827-45EF-AA12-0457977A61BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C97D8E4E-1827-45EF-AA12-0457977A61BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "8.0.0-rc2";
+        public const string Version = "8.0.0";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>8.0.0-rc2</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-esign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-esign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v8.0.0-rc2] - ESignature API v2.1-24.2.00.00 - 7/23/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v8.0.0] - ESignature API v2.1-24.2.00.00 - 9/3/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "8.0.0-rc2";
+    public const string AssemblyInformationalVersion = "8.0.0";
 }


### PR DESCRIPTION
### Breaking Changes

<details>
<summary>API Changes (Click to expand)</summary>

<div style="margin-left: 20px;">

<br/>
Added support for version v2.1-24.2.00.00 of the Docusign ESignature API.

  ## Endpoint-Specific Changes

  ### Updated [Envelopes: get](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)
  Added new optional query parameter named `include_anchor_tab_locations` of type string.

  ### Updated [Envelopes: update](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)
  Added new optional query parameter named `recycle_on_void` of type string.

  ### Updated [EnvelopeViews : createCorrect](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/)
  Request body object `correctViewRequest` has been changed to `envelopeViewRequest`.

  ## Model Changes

  ### Updated existing models

  ### `accountInformation`

  - **Added fields:**
    - `freeEnvelopeSendsRemainingForAdvancedDocGen`

  ### `accountSettingsInformation`

  - **Added fields:**
    - `defaultSigningResponsiveView`
    - `defaultSigningResponsiveViewMetadata`
    - `dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb`
    - `enableAdditionalAdvancedWebFormsFeatures`
    - `enableAdditionalAdvancedWebFormsFeaturesMetadata`

- **Removed fields:**
    - `enableSaveAsEnvelopeCustomFieldInWebForms`
    - `enableSaveAsEnvelopeCustomFieldInWebFormsMetadata`

### `bulksendingCopyDocGenFormField`

- **Added field:**
  - `rowValues`

### `notaryRecipient`

- **Added field:**
  - `canNotaryCorrectEnvelope`

### `tabAccountSettings`

- **Added field:**
  - `enableTabAgreementDetails`
  - `enableTabAgreementDetailsMetadata`


### Newly added Models

- `bulkSendingCopyDocGenFormFieldRowValue`

</div>
</details>

### Other Changes
- Improved error logging capabilities for the SDK
- Introduced async versions of `ApiClient` authorization methods.
- Corrected SDK metadata.
- Updated the SDK release version.
