### PR TITLE
Version 11.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ﻿# DocuSign C# Client Changelog
 
+## [v11.0.1] - eSignature API v2.1-26.2.01.01 - 2026-07-01
+### Changed
+- Fixed CreateChunkedUpload sending incorrect Content-Type: multipart/form-data instead of application/json.
+- Added support for version v2.1-26.2.01.01 of the DocuSign ESignature API.
+- Updated the SDK release version.
+
+
 ## [v11.0.0] - eSignature API v2.1-26.2.01.01 - 2026-06-25
 ### Added
 - **Envelopes API**: `GetEnvelopesShares` and `GetEnvelopesShare` methods for retrieving envelope share information.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: v2.1
-- **Latest SDK version (Including prerelease)**: 11.0.0
+- **Latest SDK version (Including prerelease)**: 11.0.1
 
 <a id="requirements"></a>
 ### Requirements

--- a/sdk/DocuSign.eSign.sln
+++ b/sdk/DocuSign.eSign.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{F070A0FC-1D81-4F37-BF80-52E35C60D198}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.eSign", "src\DocuSign.eSign\DocuSign.eSign.csproj", "{81FFA80B-DA37-405F-98CB-DFBA122080E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F070A0FC-1D81-4F37-BF80-52E35C60D198}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F070A0FC-1D81-4F37-BF80-52E35C60D198}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F070A0FC-1D81-4F37-BF80-52E35C60D198}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F070A0FC-1D81-4F37-BF80-52E35C60D198}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81FFA80B-DA37-405F-98CB-DFBA122080E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81FFA80B-DA37-405F-98CB-DFBA122080E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81FFA80B-DA37-405F-98CB-DFBA122080E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81FFA80B-DA37-405F-98CB-DFBA122080E5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.eSign/Api/EnvelopesApi.cs
+++ b/sdk/src/DocuSign.eSign/Api/EnvelopesApi.cs
@@ -7445,7 +7445,6 @@ namespace DocuSign.eSign.Api
 
             // to determine the Content-Type header
             String[] localVarHttpContentTypes = new String[] {
-                "multipart/form-data"
             };
             String localVarHttpContentType = this.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
 
@@ -7532,7 +7531,6 @@ namespace DocuSign.eSign.Api
 
             // to determine the Content-Type header
             String[] localVarHttpContentTypes = new String[] {
-                "multipart/form-data"
             };
             String localVarHttpContentType = this.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
 

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "11.0.0";
+        public const string Version = "11.0.1";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>11.0.0</VersionPrefix>
+    <VersionPrefix>11.0.1</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-esign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-esign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v11.0.0] - ESignature API v2.1-26.2.01.01 - 6/25/2026</PackageReleaseNotes>
+    <PackageReleaseNotes>[v11.0.1] - ESignature API v2.1-26.2.01.01 - 7/1/2026</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "11.0.0";
+    public const string AssemblyInformationalVersion = "11.0.1";
 }


### PR DESCRIPTION
### Changed
- Fixed CreateChunkedUpload sending incorrect Content-Type: multipart/form-data instead of application/json.
- Added support for version v2.1-26.2.01.01 of the DocuSign ESignature API.
- Updated the SDK release version.

